### PR TITLE
Add CORS headers to main studio Flask application

### DIFF
--- a/qiime_studio/api/v1.py
+++ b/qiime_studio/api/v1.py
@@ -5,9 +5,7 @@ from .cors import add_cors_headers
 
 v1 = Blueprint('v1', __name__)
 v1.before_request(validate_request_authentication)
-v1.after_request(add_cors_headers)
 
-
-@v1.route('/')
+@v1.route('/', methods=['GET'])
 def root():
     return jsonify(content="!")

--- a/qiime_studio/server.py
+++ b/qiime_studio/server.py
@@ -4,12 +4,15 @@ from flask import Flask, jsonify
 from gevent.pywsgi import WSGIServer
 
 from qiime_studio.api.security import make_url
+from qiime_studio.api.cors import add_cors_headers
 from qiime_studio.api.v1 import v1
 from qiime_studio.static import static_files
 
 studio = Flask('qiime_studio')
 studio.register_blueprint(v1, url_prefix='/api/0.0.1')
 studio.debug = True
+
+studio.after_request(add_cors_headers)
 
 
 @studio.route("/api/", methods=['GET'])


### PR DESCRIPTION
Fix issues with initial communication between front and backend due to no headers being applied to the request on the `/api/` endpoint, headers were only being attached to the `v1, /api/0.0.1/` Flask Blueprint. This would cause the frontend fetch on the `/api/` uri to error out and not allow the interface to get ahold of the available API versions. CORS worked as expected between the frontend and the backend if the `/0.0.1/` was concatenated onto the provided uri, so this just attaches those same before and after request methods to the main `studio` Flask app.